### PR TITLE
use regexp.MustCompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.cov
 benchmarks/new.txt
+vendor

--- a/src/c6/parser_rules.go
+++ b/src/c6/parser_rules.go
@@ -12,8 +12,10 @@ import "c6/runtime"
 import "regexp"
 import "strings"
 
-var HttpUrlPattern, _ = regexp.Compile("^https?://")
-var AbsoluteUrlPattern, _ = regexp.Compile("^[a-zA-Z]+?://")
+var (
+	HttpUrlPattern     = regexp.MustCompile("^https?://")
+	AbsoluteUrlPattern = regexp.MustCompile("^[a-zA-Z]+?://")
+)
 
 func (parser *Parser) ParseScssFile(file string) ([]ast.Statement, error) {
 	data, err := ioutil.ReadFile(file)


### PR DESCRIPTION
since err being ignored, use mustcompile to panic on bad regex patterns