### PR TITLE
readme: remove rogue backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ new language feature requests.
 ## Installation
 
 ```
-go get github.com/c9s/c6/cmd/c6`
+go get github.com/c9s/c6/cmd/c6
 ```
 
 ## Working in progress


### PR DESCRIPTION
results in:
```
$ go get github.com/c9s/c6/cmd/c6`
package github.com/c9s/c6/cmd/c6`: invalid github.com/ import path "github.com/c9s/c6/cmd/c6`"
```